### PR TITLE
Changed typo (Pupept->Puppet)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Run puppet agent in a specific node:
 
     fab puppet.agent:host=web01.example.test
 
-Show the current version of deployed Pupept code on all  nodes:
+Show the current version of deployed Puppet code on all  nodes:
 
     fab puppet.current_config
 


### PR DESCRIPTION
There is a small typo in the README.md (Pupept instead of Puppet), fixed it.

Thanks for the great control-repo :)