### PR TITLE
Add dummy_service for docker support

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -33,6 +33,7 @@ mod "jdowning/rbenv", :latest
 mod "trlinkin/noop", :latest
 mod "puppetlabs/catalog_preview", :latest
 mod "puppet/archive", :latest
+mod "puppetlabs/dummy_service", :latest
 
 # Used by profile::firewall::simple_nat
 # mod "example42/sysctl", :latest

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -46,6 +46,12 @@ Tp::Dir {
   data_module  => hiera('tp::data_module', 'tinydata'),
 }
 
+# Building Docker container support
+# This has a fix for service provider on docker
+if $virtual == 'docker' {
+  include dummy_service
+}
+
 # A useful trick to manage noop mode via hiera using the key: noop_mode
 # This needs the trlinklin-noop module
 $noop_mode = hiera('noop_mode', false)


### PR DESCRIPTION
On Docker we usually don't have services as we just run a binary.
This commit adds the puppetlabs dummy_service provider which will return
true on all propertie values.