### PR TITLE
Fixed missing checks for triggers in Vagrant environments

### DIFF
--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -1,6 +1,6 @@
 # example42 control-repo and Vagrant
 
-This contro-repo contains different customisable Vagrant environments that can be used for different purposes ad different stages of your Puppet workflow: local testing during development, continuous integration testings, semi-permanent test environviroments... 
+This contro-repo contains different customisable Vagrant environments that can be used for different purposes ad different stages of your Puppet workflow: local testing during development, continuous integration testings, semi-permanent test environments...
 
 This control-repo is by default shipped as self contained:
 
@@ -185,6 +185,7 @@ For a correct setup of the Vagrant environment you need:
         vagrant plugin install vagrant-cachier
         vagrant plugin install vagrant-vbguest
         vagrant plugin install vagrant-hostmanager
+        vagrant plugin install vagrant-triggers
 
 The Vagrant steps are basically what's done by the setup script (you may have to run it as privileged used):
 

--- a/site/profile/manifests/vagrant/plugins.pp
+++ b/site/profile/manifests/vagrant/plugins.pp
@@ -1,7 +1,7 @@
 # Installs the Vagrant plugins needed for the control repo
 class profile::vagrant::plugins (
   Array $plugins         = [] ,
-  Array $default_plugins = [ 'vagrant-hostmanager' , 'vagrant-vbguest' , 'vagrant-cachier' ],
+  Array $default_plugins = [ 'vagrant-hostmanager' , 'vagrant-vbguest' , 'vagrant-cachier', 'vagrant-triggers' ],
   String $user           = 'root',
 ) {
 

--- a/vagrant/environments/enterprise/Vagrantfile
+++ b/vagrant/environments/enterprise/Vagrantfile
@@ -95,7 +95,7 @@ Vagrant.configure("2") do |config|
       end
 
       if role != 'puppet'
-        if Vagrant.has_plugin?("vagrant-hostmanager")
+        if Vagrant.has_plugin?("vagrant-hostmanager") and Vagrant.has_plugin?('vagrant-triggers')
           # register destroy trigger to remove the node from puppet master
           node_config.trigger.after :destroy do
             node_name = @machine.name.to_s

--- a/vagrant/environments/ostest/Vagrantfile
+++ b/vagrant/environments/ostest/Vagrantfile
@@ -94,7 +94,7 @@ Vagrant.configure("2") do |config|
       end
 
       if role != 'puppet'
-        if Vagrant.has_plugin?("vagrant-hostmanager")
+        if Vagrant.has_plugin?("vagrant-hostmanager") and Vagrant.has_plugin?('vagrant-triggers')
           # register destroy trigger to remove the node from puppet master
           node_config.trigger.after :destroy do
             node_name = @machine.name.to_s

--- a/vagrant/environments/puppetinfra/Vagrantfile
+++ b/vagrant/environments/puppetinfra/Vagrantfile
@@ -95,7 +95,7 @@ Vagrant.configure("2") do |config|
       end
   
       if role != 'puppet'
-      if Vagrant.has_plugin?("vagrant-hostmanager")
+      if Vagrant.has_plugin?("vagrant-hostmanager") and Vagrant.has_plugin?('vagrant-triggers')
           # register destroy trigger to remove the node from puppet master
           node_config.trigger.after :destroy do
             node_name = @machine.name.to_s


### PR DESCRIPTION
This adds missing checks in the Vagrant environments for `vagrant-triggers` plugin.

Also updates the Vagrant profile to install that plugin.